### PR TITLE
修正专名号介绍中的 .typo-u 拼写错误

### DIFF
--- a/typo.html
+++ b/typo.html
@@ -384,7 +384,7 @@ h5,h6{font-size:1em;}
     <th rowspan="3">加强类</th>
     <td>专名号</td>
     <td><code>.typo-u</code></td>
-    <td>由于 <code>u</code> 被 HTML4 放弃，在向后兼容上推荐使用 <code>&lt;typo-u</code></td>
+    <td>由于 <code>u</code> 被 HTML4 放弃，在向后兼容上推荐使用 <code>.typo-u</code></td>
   </tr>
   <tr>
     <td>着重符</td>


### PR DESCRIPTION
>typo-u 应为 .typo-u
