### PR TITLE
将“冬青黑体”提前到“微软雅黑”前

### DIFF
--- a/typo.css
+++ b/typo.css
@@ -38,7 +38,7 @@ audio, canvas, video{
 
 /* 要注意表单元素并不继承父级 font 的问题 */
 body, button, input, select, textarea{
-  font:400 1em/1.8 Avenir, Hiragino Sans GB, Microsoft Yahei, Microsoft Sans Serif, WenQuanYi Micro Hei, sans-serif;
+  font:400 1em/1.8 Avenir, 'Hiragino Sans GB', 'Microsoft Yahei', 'Microsoft Sans Serif', 'WenQuanYi Micro Hei', sans-serif;
 }
 
 /* 去除 IE6 input/button 多余的空白 */


### PR DESCRIPTION
如果在mac上安装office会同时安装“微软雅黑”字体，但默认情况下，应该优先使用mac自带的“冬青黑体”。
@sofish 
